### PR TITLE
First pass of flipper code.

### DIFF
--- a/src/org/usfirst/frc/team5687/robot/Constants.java
+++ b/src/org/usfirst/frc/team5687/robot/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
 	public class Deadbands {
 		public static final double DRIVE_STICK = 0.1;
 		public static final double LIFT_STICK = 0.1;
+		public static final double FLIPPER_STICK = 0.1;
 	}
 	
 	public class SpeedLimits {

--- a/src/org/usfirst/frc/team5687/robot/Constants.java
+++ b/src/org/usfirst/frc/team5687/robot/Constants.java
@@ -41,10 +41,9 @@ public class Constants {
 		public static final double CLEAR_SECOND = 70.875 - HEIGHT_OFFSET;
 		public static final double DEPOSIT_HEIGHT = 64 - HEIGHT_OFFSET;
 		public static final double DEPOSIT_2_HEIGHT = 37.5 - HEIGHT_OFFSET;
-		public static final double CAN_CHUTE_HEIGHT = 53.5 - HEIGHT_OFFSET;
 		
 		// TODO get the actual measurement
-		public static final double CHUTE_HEIGHT = 52.5 - HEIGHT_OFFSET;
+		public static final double CHUTE_HEIGHT = 53.5 - HEIGHT_OFFSET;
 		
 		/*
 		public static final double HOVER_CAN = 26.5 - HEIGHT_OFFSET;

--- a/src/org/usfirst/frc/team5687/robot/Constants.java
+++ b/src/org/usfirst/frc/team5687/robot/Constants.java
@@ -39,10 +39,8 @@ public class Constants {
 		public static final double GROUND = 0;
 		public static final double CLEAR_FIRST = 45.75 - HEIGHT_OFFSET;
 		public static final double CLEAR_SECOND = 70.875 - HEIGHT_OFFSET;
-		public static final double DEPOSIT_HEIGHT = 64 - HEIGHT_OFFSET;
+		public static final double DEPOSIT_4_HEIGHT = 64 - HEIGHT_OFFSET;
 		public static final double DEPOSIT_2_HEIGHT = 37.5 - HEIGHT_OFFSET;
-		
-		// TODO get the actual measurement
 		public static final double CHUTE_HEIGHT = 53.5 - HEIGHT_OFFSET;
 		
 		/*

--- a/src/org/usfirst/frc/team5687/robot/OI.java
+++ b/src/org/usfirst/frc/team5687/robot/OI.java
@@ -85,5 +85,23 @@ public class OI {
 	public double getStackerValue() {
 		return Util.applyDeadband(joystick.getRawAxis(1), Constants.Deadbands.LIFT_STICK);
 	}
+	
+	/*
+	 * Returns the control value for the left flipper
+	 * @return double the desired speed for the flipper motor
+	 */
+	public double getLeftFlipperValue() {
+		double raw = gamepad.getRawAxis(Gamepad.Axes.LEFT_X);
+		return Util.applyDeadband(raw, Constants.Deadbands.FLIPPER_STICK);
+	}
+	
+	/*
+	 * Returns the control value for the left flipper
+	 * @return double the desired speed for the flipper motor
+	 */
+	public double getLRightFlipperValue() {
+		double raw = gamepad.getRawAxis(Gamepad.Axes.RIGHT_X);
+		return Util.applyDeadband(raw, Constants.Deadbands.FLIPPER_STICK);
+	}
 }
 

--- a/src/org/usfirst/frc/team5687/robot/OI.java
+++ b/src/org/usfirst/frc/team5687/robot/OI.java
@@ -21,7 +21,7 @@ public class OI {
 	public static final int DEPOSIT_4 = 10;
 	public static final int CHUTE = 3;
 	
-	public static Buttons boostButton = Buttons.RIGHT_STICK;
+	public static Buttons boostButton = Buttons.RB;
 	
 	/*
 	 * Constructor

--- a/src/org/usfirst/frc/team5687/robot/OI.java
+++ b/src/org/usfirst/frc/team5687/robot/OI.java
@@ -43,7 +43,7 @@ public class OI {
 		clear2Button.whenPressed(new MoveStackerToSetpoint(Constants.StackerHeights.CLEAR_FIRST));
 		clear4Button.whenPressed(new MoveStackerToSetpoint(Constants.StackerHeights.CLEAR_SECOND));
 		deposit2Button.whenPressed(new MoveStackerToSetpoint(Constants.StackerHeights.DEPOSIT_2_HEIGHT));
-		deposit4Button.whenPressed(new MoveStackerToSetpoint(Constants.StackerHeights.DEPOSIT_HEIGHT));
+		deposit4Button.whenPressed(new MoveStackerToSetpoint(Constants.StackerHeights.DEPOSIT_4_HEIGHT));
 		chuteButton.whenPressed(new MoveStackerToSetpoint(Constants.StackerHeights.CHUTE_HEIGHT));
 		
 		// Add commands to dashboard

--- a/src/org/usfirst/frc/team5687/robot/Robot.java
+++ b/src/org/usfirst/frc/team5687/robot/Robot.java
@@ -8,7 +8,6 @@ import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 import org.usfirst.frc.team5687.robot.commands.AutonomousCommandGroup;
-import org.usfirst.frc.team5687.robot.commands.ResetStacker;
 import org.usfirst.frc.team5687.robot.subsystems.DriveTrain;
 import org.usfirst.frc.team5687.robot.subsystems.Flippers;
 import org.usfirst.frc.team5687.robot.subsystems.Stacker;

--- a/src/org/usfirst/frc/team5687/robot/Robot.java
+++ b/src/org/usfirst/frc/team5687/robot/Robot.java
@@ -10,6 +10,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import org.usfirst.frc.team5687.robot.commands.AutonomousCommandGroup;
 import org.usfirst.frc.team5687.robot.commands.ResetStacker;
 import org.usfirst.frc.team5687.robot.subsystems.DriveTrain;
+import org.usfirst.frc.team5687.robot.subsystems.Flippers;
 import org.usfirst.frc.team5687.robot.subsystems.Stacker;
 
 /**
@@ -20,6 +21,7 @@ public class Robot extends IterativeRobot {
 	public static DriveTrain driveTrain;
 	public static Stacker stacker;
 	public static OI oi;
+	public static Flippers flippers;
 
     Command autonomousCommand;
     
@@ -32,6 +34,7 @@ public class Robot extends IterativeRobot {
     public void robotInit() {
 		driveTrain = new DriveTrain();
 		stacker = new Stacker();
+		flippers = new Flippers();
 		oi = new OI();
 		
 		updateDashboard();
@@ -95,5 +98,6 @@ public class Robot extends IterativeRobot {
     {
     	SmartDashboard.putData(this.driveTrain);
     	SmartDashboard.putData(this.stacker);
+    	SmartDashboard.putData(this.flippers);
     }
 }

--- a/src/org/usfirst/frc/team5687/robot/commands/MoveFlippersManually.java
+++ b/src/org/usfirst/frc/team5687/robot/commands/MoveFlippersManually.java
@@ -24,7 +24,7 @@ public class MoveFlippersManually extends Command {
 
     // Called repeatedly when this Command is scheduled to run
     protected void execute() {
-    	flippers.moveFlippers(oi.getLeftFlipperValue(), oi.getLRightFlipperValue());
+    	flippers.move(oi.getLeftFlipperValue(), oi.getLRightFlipperValue());
     }
 
     // Make this return true when this Command no longer needs to run execute()

--- a/src/org/usfirst/frc/team5687/robot/commands/MoveFlippersManually.java
+++ b/src/org/usfirst/frc/team5687/robot/commands/MoveFlippersManually.java
@@ -1,0 +1,43 @@
+package org.usfirst.frc.team5687.robot.commands;
+
+import org.usfirst.frc.team5687.robot.OI;
+import org.usfirst.frc.team5687.robot.Robot;
+import org.usfirst.frc.team5687.robot.subsystems.Flippers;
+
+import edu.wpi.first.wpilibj.command.Command;
+
+/**
+ *
+ */
+public class MoveFlippersManually extends Command {
+
+	Flippers flippers = Robot.flippers;
+	OI oi = Robot.oi;
+	
+    public MoveFlippersManually() {
+        requires(flippers);
+    }
+
+    // Called just before this Command runs the first time
+    protected void initialize() {
+    }
+
+    // Called repeatedly when this Command is scheduled to run
+    protected void execute() {
+    	flippers.moveFlippers(oi.getLeftFlipperValue(), oi.getLRightFlipperValue());
+    }
+
+    // Make this return true when this Command no longer needs to run execute()
+    protected boolean isFinished() {
+        return false;
+    }
+
+    // Called once after isFinished returns true
+    protected void end() {
+    }
+
+    // Called when another command which requires one or more of the same
+    // subsystems is scheduled to run
+    protected void interrupted() {
+    }
+}

--- a/src/org/usfirst/frc/team5687/robot/commands/MoveFlippersManually.java
+++ b/src/org/usfirst/frc/team5687/robot/commands/MoveFlippersManually.java
@@ -7,7 +7,7 @@ import org.usfirst.frc.team5687.robot.subsystems.Flippers;
 import edu.wpi.first.wpilibj.command.Command;
 
 /**
- *
+ * Command for basic manual control of the flippers
  */
 public class MoveFlippersManually extends Command {
 

--- a/src/org/usfirst/frc/team5687/robot/commands/ResetStacker.java
+++ b/src/org/usfirst/frc/team5687/robot/commands/ResetStacker.java
@@ -40,6 +40,5 @@ public class ResetStacker extends Command {
     // Called when another command which requires one or more of the same
     // subsystems is scheduled to run
     protected void interrupted() {
-    	//stacker.stop();
     }
 }

--- a/src/org/usfirst/frc/team5687/robot/subsystems/DriveTrain.java
+++ b/src/org/usfirst/frc/team5687/robot/subsystems/DriveTrain.java
@@ -15,8 +15,8 @@ import edu.wpi.first.wpilibj.RobotDrive;
 public class DriveTrain extends Subsystem {
     
 	private RobotDrive drive;
-	Talon leftMotor;
-	Talon rightMotor;
+	private Talon leftMotor;
+	private Talon rightMotor;
 	
 	/*
 	 * Constructor
@@ -60,6 +60,7 @@ public class DriveTrain extends Subsystem {
     	if(leftMotor.get() - leftSpeed > Constants.SpeedLimits.ACCELERATION_CAP) leftSpeed = leftMotor.get() - Constants.SpeedLimits.ACCELERATION_CAP;
     	if(rightSpeed - rightMotor.get() > Constants.SpeedLimits.ACCELERATION_CAP) rightSpeed = rightMotor.get() + Constants.SpeedLimits.ACCELERATION_CAP;
     	if(rightMotor.get() - rightSpeed > Constants.SpeedLimits.ACCELERATION_CAP) rightSpeed = rightMotor.get() - Constants.SpeedLimits.ACCELERATION_CAP;
+    	
     	// Determine which internal speed limit to use
     	double speedLimit = speedOverride ? 
     			Constants.SpeedLimits.BOOST : Constants.SpeedLimits.PRIMARY;

--- a/src/org/usfirst/frc/team5687/robot/subsystems/Flippers.java
+++ b/src/org/usfirst/frc/team5687/robot/subsystems/Flippers.java
@@ -1,0 +1,34 @@
+package org.usfirst.frc.team5687.robot.subsystems;
+
+import org.usfirst.frc.team5687.robot.RobotMap;
+import org.usfirst.frc.team5687.robot.commands.MoveFlippersManually;
+
+import edu.wpi.first.wpilibj.Victor;
+import edu.wpi.first.wpilibj.command.Subsystem;
+
+/**
+ *
+ */
+public class Flippers extends Subsystem {
+	
+	private Victor leftMotor;
+	private Victor rightMotor;
+
+    // Initialize your subsystem here
+    public Flippers() {
+        leftMotor = new Victor(RobotMap.flapLeft);
+        rightMotor = new Victor(RobotMap.flapRight);
+    }
+    
+    public void initDefaultCommand() {
+        // Set the default command for a subsystem here.
+        setDefaultCommand(new MoveFlippersManually());
+    }
+    
+    public void moveFlippers(double leftSpeed, double rightSpeed) {
+    	// TODO make sure the motors go the correct way with respect to the sticks, 
+    	// the negative sign may need to be switched from rightSpeed to leftSpeed
+    	leftMotor.set(leftSpeed);
+    	rightMotor.set(-rightSpeed);
+    }
+}

--- a/src/org/usfirst/frc/team5687/robot/subsystems/Flippers.java
+++ b/src/org/usfirst/frc/team5687/robot/subsystems/Flippers.java
@@ -7,7 +7,7 @@ import edu.wpi.first.wpilibj.Victor;
 import edu.wpi.first.wpilibj.command.Subsystem;
 
 /**
- *
+ * Subsystem for the tote 'pinball flippers' 
  */
 public class Flippers extends Subsystem {
 	

--- a/src/org/usfirst/frc/team5687/robot/subsystems/Flippers.java
+++ b/src/org/usfirst/frc/team5687/robot/subsystems/Flippers.java
@@ -25,7 +25,7 @@ public class Flippers extends Subsystem {
         setDefaultCommand(new MoveFlippersManually());
     }
     
-    public void moveFlippers(double leftSpeed, double rightSpeed) {
+    public void move(double leftSpeed, double rightSpeed) {
     	// TODO make sure the motors go the correct way with respect to the sticks, 
     	// the negative sign may need to be switched from rightSpeed to leftSpeed
     	leftMotor.set(leftSpeed);

--- a/src/org/usfirst/frc/team5687/robot/subsystems/Stacker.java
+++ b/src/org/usfirst/frc/team5687/robot/subsystems/Stacker.java
@@ -20,8 +20,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
  */
 public class Stacker extends PIDSubsystem {
     
-	private SpeedController flapLeft;
-	private SpeedController flapRight;
     private SpeedController stackerMotor;
     private DigitalInput lowerSensor;
     private DigitalInput upperSensor;
@@ -35,8 +33,6 @@ public class Stacker extends PIDSubsystem {
     	
     	// Setup the motor
     	stackerMotor = new Talon(RobotMap.stackerMotor);
-    	flapLeft = new Victor(RobotMap.flapLeft);
-    	flapRight = new Victor(RobotMap.flapRight);
     	
     	// Setup the limit switches
     	lowerSensor = new DigitalInput(RobotMap.hallBottom);


### PR DESCRIPTION
I added the first pass of the flipper code. The flippers are declared as a separate subsystem, for better modularity and readability. There is a single command for the subsystem (which is also the default command) that gets speed values from the OI and pass them to the move method in the subsystem. The OI uses the gamepad stick X-axes for the flipper control, and proper inversion is handled in the subsystem class. Ideally, when a gamepad stick is moved towards the center of the controller, the corresponding flipper would move in/ retract.

I also removed the CAN_CHUTE_HEIGHT constant, and just bumped the already-used CHUTE_HEIGHT constant up an inch.
